### PR TITLE
Potential fixes for 3 code scanning alerts

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -46,7 +46,9 @@ public class SSRFTask2 extends AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig.pro")) {
+    // Whitelist of allowed URLs
+    List<String> allowedUrls = List.of("http://ifconfig.pro");
+    if (allowedUrls.contains(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fixes for 3 code scanning alerts from the [Critical CodeQL alert](https://github.com/orgs/ghas-bootcamp-2025-01-10-cloudlabs100/security/campaigns/1) security campaign:
- https://github.com/ghas-bootcamp-2025-01-10-cloudlabs100/ghas-bootcamp-WebGoat/security/code-scanning/33
To fix the SSRF vulnerability, we should validate the user-provided URL against a whitelist of allowed URLs. This ensures that only pre-approved URLs can be accessed, preventing any potential SSRF attacks. We will create a list of authorized URLs and check if the provided URL is in this list before proceeding with the request.
  


- https://github.com/ghas-bootcamp-2025-01-10-cloudlabs100/ghas-bootcamp-WebGoat/security/code-scanning/32



- https://github.com/ghas-bootcamp-2025-01-10-cloudlabs100/ghas-bootcamp-WebGoat/security/code-scanning/27
To fix the problem, we need to ensure that the XML parser is always securely configured to prevent XXE attacks, regardless of the `webSession.isSecurityEnabled()` condition. This involves setting the necessary properties on the `XMLInputFactory` to disable external entity resolution unconditionally.

  - Modify the `parseXml` method in `CommentsCache` class to always disable external DTDs and schemas.
  - Ensure that the `XMLInputFactory` is securely configured before creating the `XMLStreamReader`.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
